### PR TITLE
Added status code check to _getCSDSLoginDomain

### DIFF
--- a/lib/loginSession.js
+++ b/lib/loginSession.js
@@ -124,6 +124,9 @@ class LESession {
                 if (err) {
                     cb(err);
                     return;
+                } else if (response.statusCode != 200) {
+                    cb(body);
+                    return;
                 }
                 cb(null, JSON.parse(body).baseURI);
             }


### PR DESCRIPTION
I added additional error handling to the _getCSDSLoginDomain function that checks the status code that is returned, this way if the user enters an invalid account id, they will get an error message about their domain not being found.

I added this in response to issue #1 .